### PR TITLE
chore: release v0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-post-fetcher",
-  "version": "v0.0.7",
+  "version": "v0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-post-fetcher",
-      "version": "v0.0.7",
+      "version": "v0.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notion-post-fetcher",
   "description": "fetch notion posts for twitter",
-  "version": "v0.0.7",
+  "version": "v0.1.0",
   "author": "nagauta",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

`v0.0.7` → `v0.1.0` への version bump。前回 GitHub Release を作っていない `v0.0.7` 以降の変更をまとめて `v0.1.0` としてリリースします。

## なぜ minor bump か

[#111](https://github.com/raycast-jp/notion-post-fetcher/pull/111) で thread (返信ツイート) 対応という新機能を追加し、`tweet` output の形状に `thread` フィールドを追加したため、semver 的に minor bump が妥当。

## v0.0.7 以降の変更

- feat: thread reply support (#111)
- chore(deps): codeql-action / setup-node / upload-artifact / super-linter のバージョンアップ
- chore(deps): npm 11.10.0 → 11.11.1 (#92)
- chore(deps-dev): npm-development group の更新 (#91)
- chore: pin GitHub Actions to specific commit SHAs (#90)

## Changes in this PR

- `package.json`: `v0.0.7` → `v0.1.0`
- `package-lock.json`: 同上

## マージ後の手順

1. `v0.1.0` タグを `main` の最新 commit に作成
2. `v0` mutable major タグを `v0.1.0` に付け替え
3. GitHub Release を `v0.1.0` で作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)